### PR TITLE
docs: tutorial notebooks (4 examples)

### DIFF
--- a/docs/tutorials/notebooks/af_fold_switch_crossmatch_rfah.md
+++ b/docs/tutorials/notebooks/af_fold_switch_crossmatch_rfah.md
@@ -1,0 +1,72 @@
+# AF-oriented Study: fold-state cross-matching with RfaH (2OUG vs 2LCL)
+
+This example uses ProteinMPNN-generated sequence sets from two fold states,
+then swaps one sequence region across sets to build AlphaFold test candidates.
+
+```python
+from pathlib import Path
+
+from frankenmsa.msa import MSA
+from frankenmsa.inverse_fold import run_proteinmpnn
+from frankenmsa.inverse_fold.protein_mpnn_workflow import download_pdb_by_code
+
+# 0) Download the two RfaH conformational-state structures
+pdb_2oug = download_pdb_by_code("2OUG")  # state A
+pdb_2lcl = download_pdb_by_code("2LCL")  # state B
+
+# 1) Generate sequence sets with local ProteinMPNN
+#    (requires an existing local ProteinMPNN installation)
+state_a = run_proteinmpnn(
+    pdb_path=pdb_2oug,
+    allow_upload=True,
+    runtime="local",
+    num_seqs=64,
+    sampling_temp=0.5,
+    design_chains="A",
+    fixed_chains="",
+    homomer=False,
+)
+
+state_b = run_proteinmpnn(
+    pdb_path=pdb_2lcl,
+    allow_upload=True,
+    runtime="local",
+    num_seqs=64,
+    sampling_temp=0.5,
+    design_chains="A",
+    fixed_chains="",
+    homomer=False,
+)
+
+# 2) Load both sequence sets as MSAs
+msa_a = MSA.from_a3m(state_a["a3m_path"])
+msa_b = MSA.from_a3m(state_b["a3m_path"])
+
+# 3) Swap a region from state A query into state B non-query rows
+swap_start, swap_end = 95, 140
+fragment = msa_a.query.df["sequence"].iloc[0][swap_start:swap_end]
+msa_b_cross = msa_b.copy().replace_at(
+    replacement=fragment,
+    index=swap_start,
+    include_query=False,
+)
+
+# 4) Export AF candidates (remove '-' before writing FASTA)
+def write_query_fasta(msa_obj: MSA, header: str, out_path: str) -> None:
+    seq = msa_obj.query.df["sequence"].iloc[0].replace("-", "")
+    Path(out_path).write_text(f">{header}\n{seq}\n", encoding="utf-8")
+
+write_query_fasta(msa_a, "RfaH_stateA_query", "rfah_stateA_query.fasta")
+write_query_fasta(msa_b, "RfaH_stateB_query", "rfah_stateB_query.fasta")
+write_query_fasta(msa_b_cross, "RfaH_stateB_crossmatched", "rfah_stateB_crossmatched.fasta")
+
+# Optional saved alignments
+msa_a.write_a3m("rfah_stateA.a3m")
+msa_b.write_a3m("rfah_stateB.a3m")
+msa_b_cross.write_a3m("rfah_stateB_crossmatched.a3m")
+```
+
+Recommended AlphaFold comparison:
+
+- state-B query vs cross-matched query
+- local confidence around swapped segment and neighboring contacts

--- a/docs/tutorials/notebooks/af_gfp_insertion_chrm3.md
+++ b/docs/tutorials/notebooks/af_gfp_insertion_chrm3.md
@@ -1,0 +1,56 @@
+# AF-oriented Study: GFP insertion into CHRM3 loop region
+
+This example creates a GFP-inserted sequence cohort from an MSA and exports
+FASTA sequences for downstream AlphaFold comparison.
+
+```python
+from pathlib import Path
+
+import pandas as pd
+
+from frankenmsa.align import MMSeqs2Colab
+from frankenmsa.msa import MSA
+
+# Human CHRM3 (UniProt P20309) query sequence
+chrm3_query = (
+    "MNTSVPPAVSPNATSSPSESKQLQATANMGNSSYQGAPAPAPRTTASLQTPAAGSPESVYQQLVQHLSVANRNL"
+    "LQTPGTPGSSRSPQPPGGVYVTMVVGNLAAADLILACGLWVSLAIISQPVQYNLVYLVIGRLRRWRRRR"
+)
+
+# EGFP amino-acid sequence (canonical lab variant)
+egfp = (
+    "MSKGEELFTGVVPILVELDGDVNGHKFSVSGEGEGDATYGKLTLKFICTTGKLPVPWPTLVTTFSYGVQCFSRYPDHMKQHD"
+    "FFKSAMPEGYVQERTIFFKDDGNYKTRAEVKFEGDTLVNRIELKGIDFKEDGNILGHKLEYNYNSHNVYIMADKQKNGIKVN"
+    "FKIRHNIEDGSVQLADHYQQNTPIGDGPVLLPDNHYLSTQSALSKDPNEKRDHMVLLEFVTAAGITHGMDELYK"
+)
+
+# 1) Build starting MSA
+mmseqs = MMSeqs2Colab(user_agent="frankenmsa-tutorials")
+raw_df = mmseqs.align([chrm3_query], env=True, filter=True, pairing=None)
+msa = MSA(raw_df).drop_duplicates().filter_gaps(0.5)
+
+# 2) Insert linker+GFP+linker at an example ICL3-like insertion site.
+#    This index is tutorial-specific; use a structure-aligned loop position in real projects.
+insert_index = 180
+linker = "GGGGS"
+insert_payload = linker + egfp + linker
+
+msa_inserted = msa.copy().insert_at(insert_payload, index=insert_index, include_query=True)
+
+# 3) Export WT and inserted query sequences as FASTA for AlphaFold
+def query_to_fasta(msa_obj: MSA, header: str, out_path: str) -> None:
+    seq = msa_obj.query.df["sequence"].iloc[0].replace("-", "")
+    Path(out_path).write_text(f">{header}\n{seq}\n", encoding="utf-8")
+
+query_to_fasta(msa, "CHRM3_wt_query", "chrm3_wt.fasta")
+query_to_fasta(msa_inserted, "CHRM3_GFP_insert_query", "chrm3_gfp_insert.fasta")
+
+# Optional: keep alignment artifacts for inspection
+msa.write_a3m("chrm3_reference.a3m")
+msa_inserted.write_a3m("chrm3_gfp_insert.a3m")
+```
+
+Recommended AlphaFold comparison:
+
+- WT vs GFP-inserted pLDDT and domain packing
+- local confidence around insertion boundaries (linker junctions)

--- a/docs/tutorials/notebooks/index.md
+++ b/docs/tutorials/notebooks/index.md
@@ -1,18 +1,25 @@
 # Notebook Tutorial Hub
 
-Notebook-backed tutorials will live here.
+These examples are split into two groups:
 
-## Planned structure
+- **MSA-first studies**: sequence/alignment analysis workflows
+- **AF-oriented studies**: workflows that prepare or perturb sequences for
+  downstream AlphaFold comparison
 
-- one page per tutorial notebook
-- lightweight narrative pages around longer notebooks when needed
-- shared conventions for inputs, expected runtime, and outputs
+## MSA-first examples
 
-## How to add a notebook later
+```{toctree}
+:maxdepth: 1
 
-1. Place the notebook under `docs/tutorials/notebooks/`.
-2. Add it to the local toctree on this page.
-3. Rebuild the site with `sphinx-build -b html docs docs/_build/html`.
+msa_point_mutation_tp53
+msa_region_scrambling_spike
+```
 
-The documentation is already configured not to execute notebooks during the
-build, which keeps tutorial rendering stable and predictable.
+## AF-oriented examples
+
+```{toctree}
+:maxdepth: 1
+
+af_gfp_insertion_chrm3
+af_fold_switch_crossmatch_rfah
+```

--- a/docs/tutorials/notebooks/msa_point_mutation_tp53.md
+++ b/docs/tutorials/notebooks/msa_point_mutation_tp53.md
@@ -1,0 +1,82 @@
+# MSA Study: TP53 hotspot mutation context (R248Q)
+
+This notebook uses TP53 as a mutation-context study, not just a toy
+conservation exercise. The key idea is to compare **WT-seeded** and
+**R248Q-seeded** homolog neighborhoods and inspect how residue preferences shift
+at functionally important positions.
+
+R248 is a canonical TP53 DNA-contact hotspot in cancer cohorts.
+
+```python
+from collections import Counter
+import pandas as pd
+
+from frankenmsa.align import MMSeqs2Colab
+from frankenmsa.msa import MSA
+
+# Human TP53 (UniProt P04637)
+tp53_query = (
+    "SQETFSDLWKLLPENNVLSPLPSQAMDDLMLSPDDIEQWFTEDPGPDEAPRMPEAAPPVAPAPAAPTPAAPAP"
+    "SWPLSSSVPSQKTYQGSYGFRLGFLHSGTAKSVTCTYSPALNKMFCQLAKTCPVQLWVDSTPPPGTRVRAMAIY"
+    "KQSQHMTEVVRRCPHHERCSDSDGLAPPQHLIRVEGNLRVEYLDDRNTFRHSVVVPYEPPEVGSDCTTIHYNYM"
+    "CNSSCMGGMNRRPILTIITLEDSSGNLLGRNSFEVRVCACPGRDRRTEEENLRKKGEPHHELPPGSTKRALPTST"
+)
+
+# 0-based mutation index for residue 248
+mut_index = 247
+tp53_r248q = tp53_query[:mut_index] + "Q" + tp53_query[mut_index + 1 :]
+
+mmseqs = MMSeqs2Colab(user_agent="frankenmsa-tutorials")
+
+# 1) Build WT-seeded and mutant-seeded MSAs independently
+wt_raw = mmseqs.align([tp53_query], env=True, filter=True, pairing=None)
+mut_raw = mmseqs.align([tp53_r248q], env=True, filter=True, pairing=None)
+
+msa_wt = MSA(wt_raw).drop_duplicates().filter_gaps(0.4)
+msa_mut = MSA(mut_raw).drop_duplicates().filter_gaps(0.4)
+
+# 2) Compare residue preference shifts at key TP53 positions
+def residue_frequencies(msa: MSA, pos_0based: int, top_n: int = 8) -> pd.Series:
+    residues = []
+    for s in msa.df["sequence"]:
+        if pos_0based < len(s):
+            aa = s[pos_0based]
+            if aa != "-":
+                residues.append(aa)
+    counts = Counter(residues)
+    total = sum(counts.values()) or 1
+    freq = {aa: c / total for aa, c in counts.items()}
+    return pd.Series(freq).sort_values(ascending=False).head(top_n)
+
+# canonical DNA-contact/hotspot positions in TP53 core domain
+positions = {
+    "R175 hotspot": 174,
+    "R248 hotspot": 247,
+    "R273 hotspot": 272,
+}
+
+for label, pos in positions.items():
+    wt_freq = residue_frequencies(msa_wt, pos)
+    mut_freq = residue_frequencies(msa_mut, pos)
+    table = pd.concat(
+        [wt_freq.rename("WT-seeded"), mut_freq.rename("R248Q-seeded")], axis=1
+    ).fillna(0.0)
+    print(f"\n=== {label} (1-based {pos+1}) ===")
+    print(table.head(10))
+
+# 3) Save artifacts for downstream workflows
+msa_wt.write_a3m("tp53_wt_seeded.a3m")
+msa_mut.write_a3m("tp53_r248q_seeded.a3m")
+```
+
+## Why this is useful
+
+The output gives a practical shortlist of context residues that co-vary
+differently between WT- and mutant-seeded neighborhoods. That can drive
+follow-up design/structure work, for example:
+
+- choose compensatory candidates near the DNA-binding surface (e.g., positions
+  around 175/248/273) for combinatorial mutation sets,
+- run AlphaFold/other structure pipelines on selected combinations,
+- dock to DNA or compare interface confidence/ranking between WT-like and
+  mutant-like sequence contexts.

--- a/docs/tutorials/notebooks/msa_region_scrambling_spike.md
+++ b/docs/tutorials/notebooks/msa_region_scrambling_spike.md
@@ -1,0 +1,78 @@
+# MSA Study: regional scrambling and functional site identification in SARS-CoV-2 Spike
+
+The goal here is not simply to observe post-scramble conservation noise, but to
+use scrambling as a **control** in combination with AF structure prediction.
+
+The idea: scramble the Receptor Binding Motif (RBM) — the primary ACE2-contact
+region — then feed both the WT MSA and the scrambled MSA to AlphaFold. Structure
+confidence (pLDDT) and predicted interface RMSD give a quantitative readout of
+how much that region's evolutionary signal contributes to predicted fold quality
+and interface geometry. No a priori knowledge of the answer is required: if pLDDT
+drops and/or the ACE2-contact loop geometry diverges, the MSA signal for that
+window was structurally informative. If it doesn't, the region is likely encoded
+more locally.
+
+```python
+from pathlib import Path
+
+import pandas as pd
+
+from frankenmsa.align import MMSeqs2Colab
+from frankenmsa.msa import MSA
+
+# SARS-CoV-2 Spike RBD (UniProt P0DTC2), residues covering RBD+RBM
+spike_query = (
+    "MFVFLVLLPLVSSQCVNLTTRTQLPPAYTNSFTRGVYYPDKVFRSSVLHSTQDLFLPFFSNVTWFHAIHVSGTNGT"
+    "KRFDNPVLPFNDGVYFASTEKSNIIRGWIFGTTLDSKTQSLLIVNNATNVVIKVCEFQFCNDPFLGVYYHKNNKSW"
+    "MESEFRVYSSANNCTFEYVSQPFLMDLEGKQGNFKNLREFVFKNIDGYFKIYSKHTPINLVRDLPQGFSALEPLVD"
+    "LPIGINITRFQTLLALHRSYLTPGDSSSGWTAGAAAYYVGYLQPRTFLLKYNENGTITDAVDCALDPLSETKCTLK"
+)
+
+# 1) Build and clean MSA
+mmseqs = MMSeqs2Colab(user_agent="frankenmsa-tutorials")
+raw_df = mmseqs.align([spike_query], env=True, filter=True, pairing=None)
+msa_ref = MSA(raw_df).drop_duplicates().filter_gaps(0.5)
+
+# 2) Produce two scrambled variants of the RBM window.
+#    Position 438-506 (0-based) covers the primary ACE2-contact surface.
+#    Use different random seeds so you have three distinct AF inputs.
+rbm_start, rbm_end = 438, 506
+
+msa_scrambled_1 = msa_ref.copy().shuffle_msa(
+    start=rbm_start, end=rbm_end, preserve_gaps=True, random_state=7
+)
+msa_scrambled_2 = msa_ref.copy().shuffle_msa(
+    start=rbm_start, end=rbm_end, preserve_gaps=True, random_state=42
+)
+
+# 3) Export MSAs for AlphaFold input
+msa_ref.write_a3m("spike_reference.a3m")
+msa_scrambled_1.write_a3m("spike_rbm_scrambled_s7.a3m")
+msa_scrambled_2.write_a3m("spike_rbm_scrambled_s42.a3m")
+
+# 4) Export the corresponding query sequences as FASTA (sequence is unchanged;
+#    only the alignment context behind each position differs).
+def query_to_fasta(msa: MSA, name: str, out_path: str) -> None:
+    seq = msa.query.df["sequence"].iloc[0].replace("-", "")
+    Path(out_path).write_text(f">{name}\n{seq}\n", encoding="utf-8")
+
+query_to_fasta(msa_ref, "Spike_WT_context", "spike_query_ref.fasta")
+query_to_fasta(msa_scrambled_1, "Spike_RBM_scrambled_s7", "spike_query_scrambled_s7.fasta")
+query_to_fasta(msa_scrambled_2, "Spike_RBM_scrambled_s42", "spike_query_scrambled_s42.fasta")
+```
+
+## Downstream AlphaFold comparison
+
+Run AlphaFold (or ColabFold with MSA injection) once with the reference A3M
+and once for each scrambled A3M:
+
+1. **pLDDT at RBM positions**: a drop in the scrambled runs indicates that
+   coevolutionary signal in the RBM window is contributing to local fold
+   confidence at those residues.
+2. **Predicted interface geometry** (with ACE2, PDB 6M0J chain B as a template):
+   if scrambling disrupts the contact loop geometry, the region carries
+   productive MSA signal for interface prediction. If geometry is unchanged,
+   the structure is locally rigid regardless of MSA depth at that site.
+3. **Two scrambled seeds** act as a control for randomness: consistent effects
+   across both scrambles are more likely to reflect MSA signal loss rather than
+   a specific residue rearrangement artefact.


### PR DESCRIPTION
Adds four tutorial notebooks split 2+2 across MSA-first and AF-oriented use cases.

**MSA-first**
- `msa_point_mutation_tp53.md` — WT vs R248Q-seeded independent MMSeqs alignments; residue-frequency shifts at hotspot positions 174, 247, 272
- `msa_region_scrambling_spike.md` — scrambles Spike RBM window (438–506) with two random seeds; exports A3Ms + FASTAs for AF pLDDT / interface-geometry comparison

**AF-oriented**
- `af_gfp_insertion_chrm3.md` — GFP insertion into CHRM3 ICL3, exports for AF
- `af_fold_switch_crossmatch_rfah.md` — RfaH state-A/B segment swap, exports for AF comparison

Also updates `index.md` to the 2+2 hub structure.